### PR TITLE
Reload the Noah accumulators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ serde = { version = "1.0.124", features = ["derive"] }
 noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.4.5" }
 noah-crypto = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.4.5" }
 noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.4.5" }
+noah-accumulators  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.4.5" }
 ed25519-dalek = { package = "noah-ed25519-dalek",version = "4.0.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,4 @@ pub use ownermemo::*;
 pub use noah_algebra;
 pub use noah_crypto;
 pub use noah as noah_api;
+pub use noah_accumulators;


### PR DESCRIPTION
Since the platform main repo uses Noah accumulators, here, for simplicity, we reload it from here.